### PR TITLE
Pin generic firmware version to v3.0.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -32,7 +32,7 @@ board_build.partitions = partitions.csv
 
 framework = espidf
 
-lib_deps = https://github.com/energietransitie/twomes-generic-esp-firmware
+lib_deps = https://github.com/energietransitie/twomes-generic-esp-firmware#v3.0.0
 
 ;Build and Debug settings:
 build_flags = 

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,16 +36,16 @@ lib_deps = https://github.com/energietransitie/twomes-generic-esp-firmware#v3.0.
 
 ;Build and Debug settings:
 build_flags = 
-    -DCORE_DEBUG_LEVEL=4                ;Uncommented enables debugging
-    -DLOG_LOCAL_LEVEL=4                 ;Uncommented enables debugging
+;   -DCORE_DEBUG_LEVEL=4                ;Uncommented enables debugging
+;   -DLOG_LOCAL_LEVEL=4                 ;Uncommented enables debugging
 ;   -DCONFIG_TWOMES_CUSTOM_GPIO         ;Uncommented enables custom GPIO mapping 
     -DCONFIG_TWOMES_PROV_TRANSPORT_BLE  ; uncomment line to support BLE provisioning
 ;   -DCONFIG_TWOMES_PROV_TRANSPORT_SOFTAP ; uncomment line to support SoftAP provisioning
 ;   -DCONFIG_TWOMES_STRESS_TEST         ;line commented = disabled; line uncommented = enabled
     -DCONFIG_TWOMES_PRESENCE_DETECTION  ;line commented = disabled; line uncommented = enabled
 ;   -DCONFIG_TWOMES_PRESENCE_DETECTION_PARALLEL ;line commented = disabled; line uncommented = enabled; keep disabled for now
-    -DCONFIG_TWOMES_TEST_SERVER         ;line uncommented = use test server; line commented = use other server
-;   -DCONFIG_TWOMES_PRODUCTION_SERVER   ;line uncommented = use production server; line commented = use other server
+;   -DCONFIG_TWOMES_TEST_SERVER         ;line uncommented = use test server; line commented = use other server
+    -DCONFIG_TWOMES_PRODUCTION_SERVER   ;line uncommented = use production server; line commented = use other server
 ;   -DCONFIG_TWOMES_OTA_FIRMWARE_UPDATE ;line commented = disabled; line uncommented = enabled
     -D"$PIOENV"
 


### PR DESCRIPTION
This was the newest version of the library (and still is, at the time of writing) which was used in the deployment of the Brains4Buildings devices.