### PR TITLE
Stop measuring when SCD41 is not connected

### DIFF
--- a/src/scd41_task.cpp
+++ b/src/scd41_task.cpp
@@ -25,21 +25,19 @@ void SCD41Task(void *taskInfo)
 	for (int i = 0; i < 3; i++)
 	{
 		err = co2_read(SCD41_ADDR, scd41Data);
+		if (err != ESP_OK)
+		{
+			ESP_LOGW(taskName, "CRC was incorrect or no sensor wat attached.");
+			return;
+		}
 	}
 
-	if (err == ESP_OK)
-	{
-		Measurements::Measurement co2Concentration("CO2concentration", scd41Data[0]);
-		secureUploadQueue.AddMeasurement(co2Concentration);
+	Measurements::Measurement co2Concentration("CO2concentration", scd41Data[0]);
+	secureUploadQueue.AddMeasurement(co2Concentration);
 
-		Measurements::Measurement roomTemp("roomTemp", scd41_temp_raw_to_celsius(scd41Data[1]));
-		secureUploadQueue.AddMeasurement(roomTemp);
+	Measurements::Measurement roomTemp("roomTemp", scd41_temp_raw_to_celsius(scd41Data[1]));
+	secureUploadQueue.AddMeasurement(roomTemp);
 
-		Measurements::Measurement relativeHumidity("relativeHumidity", scd41_rh_raw_to_percent(scd41Data[2]));
-		secureUploadQueue.AddMeasurement(relativeHumidity);
-	}
-	else
-	{
-		ESP_LOGW(taskName, "CRC was incorrect or no sensor wat attached.");
-	}
+	Measurements::Measurement relativeHumidity("relativeHumidity", scd41_rh_raw_to_percent(scd41Data[2]));
+	secureUploadQueue.AddMeasurement(relativeHumidity);
 }


### PR DESCRIPTION
The previous code allowed for the ability to do three failed measurements. I changed this to fail the first time and not try two more times. This saves 10 seconds of time when an SCD41 is disconnected or faulty.

## Result
Here you can see that after one try, it stops, where it would continue before:
![Screenshot from 2022-10-27 16-24-13](https://user-images.githubusercontent.com/43145188/198317410-24b2b6e1-ecf8-4ee5-bd35-cc4508fb44b7.png)

> I am unsure about why it says `%.1f`, but there are more instances when task names seem like they are read from uninitialized memory. 
> I created a trello card for this: https://trello.com/c/pWtVVMLd