### PR TITLE
Build multiple environments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Build PlatformIO project
         env:
           PLATFORMIO_ENV: ${{ matrix.platformio_env }}
+          PLATFORMIO_BUILD_FLAGS: -DCONFIG_TWOMES_TEST_SERVER
         run: pio run -e $PLATFORMIO_ENV
 
       # Perform the code analysis.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,16 @@ jobs:
     environment: production
     strategy:
       matrix:
-        # List all of the PlatformIO platforms to build
-        platformio_env: [ESP32DEV, M5STACK_COREINK]
+        # List all of the PlatformIO platforms to build.
+        platformio_env: 
+          - ESP32DEV
+          - M5STACK_COREINK
+
+        # Twomes server environments to build for.
+        twomes_server_env:
+          - TEST_SERVER
+          - PRODUCTION_SERVER
+
     env:
       # Directory where the to-be-archived files are.
       BUILD_DIR: .pio/build/${{ matrix.platformio_env }}
@@ -50,6 +58,7 @@ jobs:
       - name: Build PlatformIO project
         env:
           PLATFORMIO_ENV: ${{ matrix.platformio_env }}
+          PLATFORMIO_BUILD_FLAGS: -DCONFIG_TWOMES_${{ matrix.twomes_server_env }}
         run: pio run -e $PLATFORMIO_ENV
 
       # Create secure_boot_signing_key.pem from GH secret SECURE_BOOTLOADER_SIGNING_KEY.
@@ -62,11 +71,11 @@ jobs:
       - name: Sign firmware
         uses: espressif/esp-idf-ci-action@main
         with:
-          command: espsecure.py sign_data -v1 --keyfile secure_boot_signing_key.pem --output $BUILD_DIR/firmware-signed_${{ matrix.platformio_env }}.bin $BUILD_DIR/firmware.bin
+          command: espsecure.py sign_data -v1 --keyfile secure_boot_signing_key.pem --output $BUILD_DIR/firmware-signed_${{ matrix.platformio_env }}_${{ matrix.twomes_server_env }}.bin $BUILD_DIR/firmware.bin
       
       # Set ARCHIVE_NAME variable from ARCHIVE_PREFIX and tag name.
       - name: Set ARCHIVE_NAME
-        run: echo "ARCHIVE_NAME=${ARCHIVE_PREFIX}_${{ matrix.platformio_env }}_${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+        run: echo "ARCHIVE_NAME=${ARCHIVE_PREFIX}_${{ matrix.platformio_env }}_${{ matrix.twomes_server_env }}_${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       
       # Archive binary files.
       - name: Archive binary files
@@ -81,4 +90,4 @@ jobs:
           draft: true
           files: |
             ${{ env.BUILD_DIR }}/${{ env.ARCHIVE_NAME }}.zip
-            ${{ env.BUILD_DIR }}/firmware-signed_${{ matrix.platformio_env }}.bin
+            ${{ env.BUILD_DIR }}/firmware-signed_${{ matrix.platformio_env }}_${{ matrix.twomes_server_env }}.bin

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ build_flags =
     -DCONFIG_TWOMES_PRESENCE_DETECTION  ;line commented = disabled; line uncommented = enabled
 ;   -DCONFIG_TWOMES_PRESENCE_DETECTION_PARALLEL ;line commented = disabled; line uncommented = enabled; keep disabled for now
 ;   -DCONFIG_TWOMES_TEST_SERVER         ;line uncommented = use test server; line commented = use other server
-    -DCONFIG_TWOMES_PRODUCTION_SERVER   ;line uncommented = use production server; line commented = use other server
+;   -DCONFIG_TWOMES_PRODUCTION_SERVER   ;line uncommented = use production server; line commented = use other server
 ;   -DCONFIG_TWOMES_OTA_FIRMWARE_UPDATE ;line commented = disabled; line uncommented = enabled
     -D"$PIOENV"
 


### PR DESCRIPTION
## Changes
The release workflow now builds for the test and production server and uploads binary files for those environments in the release.

## Trello card
https://trello.com/c/Nq1ZShIR